### PR TITLE
チャットルームの作成・参加・招待の実装

### DIFF
--- a/backend/src/modules/room/repositories/interfaces/interface.room-member.repository.ts
+++ b/backend/src/modules/room/repositories/interfaces/interface.room-member.repository.ts
@@ -1,3 +1,4 @@
+import { UserConnection } from 'src/modules/user/graphql-types/objects/user-connection.model';
 import { RoomMemberConnection } from '../../graphql-types/objects/room-member-connection.model';
 
 export interface FetchRoomMembersConnectionParams {
@@ -18,6 +19,14 @@ export interface IRoomMemberRepository {
   fetchRoomMembersConnection(
     params: FetchRoomMembersConnectionParams,
   ): Promise<RoomMemberConnection>;
+  existsByRoomIdAndUserId(roomId: string, userId: string): Promise<boolean>;
+  findAvailableUsersForRoom(
+    roomId: string,
+    first?: number,
+    after?: string,
+    last?: number,
+    before?: string,
+  ): Promise<UserConnection>;
 }
 
 export const IRoomMemberRepositoryToken = Symbol('IRoomMemberRepository');

--- a/backend/src/modules/room/repositories/room-member.prisma.repository.ts
+++ b/backend/src/modules/room/repositories/room-member.prisma.repository.ts
@@ -1,3 +1,6 @@
+import { UserConnection } from 'src/modules/user/graphql-types/objects/user-connection.model';
+import { UserEdge } from 'src/modules/user/graphql-types/objects/user-edge.model';
+import { userIncludeWithProfileAndStatus } from 'src/modules/user/repositories/user.prisma.include';
 import {
   ConflictException,
   Injectable,
@@ -114,6 +117,73 @@ export class RoomMemberPrismaRepository implements IRoomMemberRepository {
       cursor: member.id,
       joinedAt: member.joinedAt,
       invitedBy: member.inviter,
+    }));
+
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage: isForward ? hasExtra : false,
+        hasPreviousPage: !isForward ? hasExtra : false,
+        startCursor: sliced[0]?.id ?? null,
+        endCursor: sliced[sliced.length - 1]?.id ?? null,
+      },
+      totalCount,
+    };
+  }
+
+  async existsByRoomIdAndUserId(
+    roomId: string,
+    userId: string,
+  ): Promise<boolean> {
+    const count = await this.prisma.roomMember.count({
+      where: { roomId, userId },
+    });
+    return count > 0;
+  }
+
+  async findAvailableUsersForRoom(
+    roomId: string,
+    first?: number,
+    after?: string,
+    last?: number,
+    before?: string,
+  ): Promise<UserConnection> {
+    // 既に参加しているユーザーID一覧を取得
+    const roomMembers = await this.prisma.roomMember.findMany({
+      where: { roomId },
+      select: { userId: true },
+    });
+    const joinedUserIds = roomMembers.map((m) => m.userId);
+
+    // ページネーション設定
+    const take = first ?? last ?? 20;
+    const cursor = after ?? before;
+    const cursorObj = cursor ? { id: cursor } : undefined;
+    const isForward = !!first;
+    const orderBy = { createdAt: 'asc' as const };
+
+    // 未参加ユーザーを取得
+    const where: any = {
+      id: { notIn: joinedUserIds },
+      userStatusId: 'ACTIVE',
+    };
+
+    const totalCount = await this.prisma.user.count({ where });
+
+    const users = await this.prisma.user.findMany({
+      where,
+      take: isForward ? take + 1 : -(take + 1),
+      skip: cursor ? 1 : 0,
+      cursor: cursorObj,
+      orderBy,
+      include: userIncludeWithProfileAndStatus,
+    });
+
+    const hasExtra = users.length > take;
+    const sliced = hasExtra ? users.slice(0, take) : users;
+    const edges: UserEdge[] = sliced.map((user) => ({
+      node: user,
+      cursor: user.id,
     }));
 
     return {

--- a/backend/src/modules/room/room.module.ts
+++ b/backend/src/modules/room/room.module.ts
@@ -11,6 +11,8 @@ import { ListRoomUseCase } from './usecases/list-room.usecase';
 import { RoomMemberPrismaRepository } from './repositories/room-member.prisma.repository';
 import { IRoomMemberRepositoryToken } from './repositories/interfaces/interface.room-member.repository';
 import { ListRoomMembersByRoomUseCase } from './usecases/list-room-members-by-room.usecase';
+import { CheckUserJoinedRoomUseCase } from './usecases/check-user-joined-room.usecase';
+import { GetAvailableUsersForRoomUseCase } from './usecases/get-available-users-for-room.usecase';
 
 @Module({
   imports: [UserModule],
@@ -22,6 +24,8 @@ import { ListRoomMembersByRoomUseCase } from './usecases/list-room-members-by-ro
     InviteUserToRoomUseCase,
     ListRoomUseCase,
     ListRoomMembersByRoomUseCase,
+    CheckUserJoinedRoomUseCase,
+    GetAvailableUsersForRoomUseCase,
     {
       provide: IRoomRepositoryToken,
       useClass: RoomPrismaRepository,

--- a/backend/src/modules/room/room.resolvers.ts
+++ b/backend/src/modules/room/room.resolvers.ts
@@ -27,6 +27,9 @@ import { RoomMemberConnection } from './graphql-types/objects/room-member-connec
 import { ListRoomMembersByRoomUseCase } from './usecases/list-room-members-by-room.usecase';
 import { isUUID } from 'class-validator';
 import { BadRequestException } from '@nestjs/common';
+import { CheckUserJoinedRoomUseCase } from './usecases/check-user-joined-room.usecase';
+import { GetAvailableUsersForRoomUseCase } from './usecases/get-available-users-for-room.usecase';
+import { UserConnection } from '../user/graphql-types/objects/user-connection.model';
 
 @Resolver(() => Room)
 export class RoomResolver {
@@ -38,8 +41,9 @@ export class RoomResolver {
     private readonly inviteUserToRoomUseCase: InviteUserToRoomUseCase,
     private readonly listRoomUseCase: ListRoomUseCase,
     private readonly listRoomMembersByRoomUseCase: ListRoomMembersByRoomUseCase,
+    private readonly checkUserJoinedRoomUseCase: CheckUserJoinedRoomUseCase,
+    private readonly getAvailableUsersForRoomUseCase: GetAvailableUsersForRoomUseCase,
   ) {}
-
   @Query(() => Room, { nullable: true })
   async room(@Args() args: RoomArgs) {
     return this.getRoomUseCase.execute(args.id);
@@ -82,6 +86,21 @@ export class RoomResolver {
     );
   }
 
+  @Query(() => UserConnection)
+  async availableUsersForRoom(
+    @Args('roomId', { type: () => ID }) roomId: string,
+    @Args() paginationArgs: PaginationArgs,
+  ): Promise<UserConnection> {
+    const { first, after, last, before } = paginationArgs;
+    return this.getAvailableUsersForRoomUseCase.execute(
+      roomId,
+      first,
+      after,
+      last,
+      before,
+    );
+  }
+
   @ResolveField()
   async creator(@Parent() room: Room) {
     const { createUserId } = room;
@@ -116,5 +135,13 @@ export class RoomResolver {
     @CurrentUser() user: UserPayload,
   ) {
     return this.inviteUserToRoomUseCase.execute(input, user);
+  }
+
+  @Query(() => Boolean)
+  async isJoinedRoom(
+    @Args('roomId', { type: () => ID }) roomId: string,
+    @CurrentUser() user: UserPayload,
+  ): Promise<boolean> {
+    return this.checkUserJoinedRoomUseCase.execute(roomId, user);
   }
 }

--- a/backend/src/modules/room/usecases/check-user-joined-room.usecase.ts
+++ b/backend/src/modules/room/usecases/check-user-joined-room.usecase.ts
@@ -1,0 +1,39 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  IRoomRepository,
+  IRoomRepositoryToken,
+} from '../repositories/interfaces/interface.room.repository';
+import {
+  IRoomMemberRepository,
+  IRoomMemberRepositoryToken,
+} from '../repositories/interfaces/interface.room-member.repository';
+import { UserPayload } from 'src/modules/auth/types/user-payload';
+import { isUUID } from 'class-validator';
+
+@Injectable()
+export class CheckUserJoinedRoomUseCase {
+  constructor(
+    @Inject(IRoomRepositoryToken)
+    private readonly roomRepository: IRoomRepository,
+    @Inject(IRoomMemberRepositoryToken)
+    private readonly roomMemberRepository: IRoomMemberRepository,
+  ) {}
+
+  async execute(roomId: string, user: UserPayload): Promise<boolean> {
+    if (!isUUID(roomId)) {
+      throw new BadRequestException('roomId must be a valid UUID');
+    }
+
+    const room = await this.roomRepository.findById(roomId);
+    if (!room) {
+      throw new NotFoundException(`Room with id ${roomId} not found`);
+    }
+
+    return this.roomMemberRepository.existsByRoomIdAndUserId(roomId, user.sub);
+  }
+}

--- a/backend/src/modules/room/usecases/create-room.usecase.ts
+++ b/backend/src/modules/room/usecases/create-room.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import {
   IRoomRepository,
   IRoomRepositoryToken,
@@ -6,19 +6,33 @@ import {
 import { Room } from '../graphql-types/objects/room.model';
 import { CreateRoomInput } from '../graphql-types/inputs/create-room.input';
 import { UserPayload } from 'src/modules/auth/types/user-payload';
+import {
+  IRoomMemberRepository,
+  IRoomMemberRepositoryToken,
+} from '../repositories/interfaces/interface.room-member.repository';
 
 @Injectable()
 export class CreateRoomUseCase {
   constructor(
     @Inject(IRoomRepositoryToken)
     private readonly roomRepository: IRoomRepository,
+    @Inject(IRoomMemberRepositoryToken)
+    private readonly roomMemberRepository: IRoomMemberRepository,
   ) {}
 
   async execute(input: CreateRoomInput, user: UserPayload): Promise<Room> {
-    return await this.roomRepository.create(
+    const room = await this.roomRepository.create(
       input.name,
       input.description,
       user.sub,
     );
+
+    await this.roomMemberRepository.addMember(room.id, user.sub);
+
+    const updatedRoom = await this.roomRepository.findById(room.id);
+    if (!updatedRoom) {
+      throw new NotFoundException(`Room with id ${room.id} not found`);
+    }
+    return updatedRoom;
   }
 }

--- a/backend/src/modules/room/usecases/get-available-users-for-room.usecase.ts
+++ b/backend/src/modules/room/usecases/get-available-users-for-room.usecase.ts
@@ -1,0 +1,30 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { UserConnection } from 'src/modules/user/graphql-types/objects/user-connection.model';
+import {
+  IRoomMemberRepository,
+  IRoomMemberRepositoryToken,
+} from '../repositories/interfaces/interface.room-member.repository';
+
+@Injectable()
+export class GetAvailableUsersForRoomUseCase {
+  constructor(
+    @Inject(IRoomMemberRepositoryToken)
+    private readonly roomMemberRepository: IRoomMemberRepository,
+  ) {}
+
+  async execute(
+    roomId: string,
+    first?: number,
+    after?: string,
+    last?: number,
+    before?: string,
+  ): Promise<UserConnection> {
+    return this.roomMemberRepository.findAvailableUsersForRoom(
+      roomId,
+      first,
+      after,
+      last,
+      before,
+    );
+  }
+}

--- a/backend/src/modules/user/graphql-types/objects/user-connection.model.ts
+++ b/backend/src/modules/user/graphql-types/objects/user-connection.model.ts
@@ -1,0 +1,15 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { PageInfo } from 'src/shared/graphql/graphql-types/objects/page-info.model';
+import { UserEdge } from './user-edge.model';
+
+@ObjectType()
+export class UserConnection {
+  @Field(() => PageInfo)
+  pageInfo: PageInfo;
+
+  @Field(() => [UserEdge])
+  edges: UserEdge[];
+
+  @Field(() => Int)
+  totalCount: number;
+}

--- a/backend/src/modules/user/graphql-types/objects/user-edge.model.ts
+++ b/backend/src/modules/user/graphql-types/objects/user-edge.model.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { User } from './user.model';
+
+@ObjectType()
+export class UserEdge {
+  @Field()
+  cursor: string;
+
+  @Field(() => User)
+  node: User;
+}

--- a/backend/src/shared/graphql/schema.gql
+++ b/backend/src/shared/graphql/schema.gql
@@ -148,6 +148,17 @@ type RoomMemberConnection {
   totalCount: Int!
 }
 
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+  totalCount: Int!
+}
+
 type MessageType {
   """メッセージタイプ ID"""
   id: ID!
@@ -246,6 +257,22 @@ type Query {
     """ページネーション用のカーソル（前ページ）"""
     before: String
   ): RoomMemberConnection!
+  availableUsersForRoom(
+    roomId: ID!
+
+    """取得する最初の件数"""
+    first: Int
+
+    """取得する最後の件数"""
+    last: Int
+
+    """ページネーション用のカーソル（次ページ）"""
+    after: String
+
+    """ページネーション用のカーソル（前ページ）"""
+    before: String
+  ): UserConnection!
+  isJoinedRoom(roomId: ID!): Boolean!
   messagesConnectionByRoom(
     roomId: ID!
 

--- a/docs/GraphQL設計/GraphQLスキーマ設計書.md
+++ b/docs/GraphQL設計/GraphQLスキーマ設計書.md
@@ -2,13 +2,15 @@
 
 ## Query 一覧
 
-| Query 名                 | 説明                           |
-| ------------------------ | ------------------------------ |
-| room                     | チャットルームを単体取得       |
-| roomsConnection          | チャットルーム一覧用取得       |
-| messagesConnectionByRoom | チャットルームのメッセージ取得 |
-| membersConnectionByRoom  | チャットルームの参加者取得     |
-| messageTypes             | メッセージタイプ一覧取得       |
+| Query 名                 | 説明                                         |
+| ------------------------ | -------------------------------------------- |
+| room                     | チャットルームを単体取得                     |
+| roomsConnection          | チャットルーム一覧用取得                     |
+| isJoinedRoom             | チャットルーム参加有無                       |
+| messagesConnectionByRoom | チャットルームのメッセージ取得               |
+| membersConnectionByRoom  | チャットルームの参加者取得                   |
+| messageTypes             | メッセージタイプ一覧取得                     |
+| availableUsersForRoom    | ルームに未参加のユーザー一覧取得（招待候補） |
 
 ```graphql
 type Query {
@@ -20,6 +22,7 @@ type Query {
     before: String
     filter: RoomFilterInput
   ): RoomConnection!
+  isJoinedRoom(roomId: ID!): Boolean!
   messagesConnectionByRoom(
     roomId: ID!
     first: Int
@@ -35,6 +38,13 @@ type Query {
     before: String
   ): RoomMemberConnection!
   messageTypes: [MessageType!]!
+  availableUsersForRoom(
+    roomId: ID!
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): UserConnection!
 }
 ```
 
@@ -46,8 +56,6 @@ after: 指定されたカーソルの「後」の要素から取得します。�
 last: 逆順で取得したい件数を指定します。before 引数と組み合わせて使用します。
 before: 指定されたカーソルの「前」の要素から取得します。
 ```
-
----
 
 ## Mutation 一覧
 
@@ -85,26 +93,28 @@ type Subscription {
 
 ## 型定義
 
-| 種類  | 名称                  | 内容                             |
-| ----- | --------------------- | -------------------------------- |
-| type  | User                  | ユーザー                         |
-| type  | UserStatus            | ユーザーステータス               |
-| type  | Profile               | ユーザープロフィール             |
-| type  | Room                  | チャットルーム                   |
-| type  | RoomConnection        | チャットルームコネクション       |
-| type  | RoomEdge              | チャットルームエッジ             |
-| type  | RoomMemberConnection  | チャットルーム参加者コネクション |
-| type  | RoomMemberEdge        | チャットルーム参加者エッジ       |
-| type  | Message               | メッセージ                       |
-| type  | MessageType           | メッセージタイプ                 |
-| type  | MessageConnection     | メッセージコネクション           |
-| type  | MessageEdge           | メッセージエッジ                 |
-| type  | PageInfo              | ページ情報                       |
-| input | CreateMessageInput    | メッセージ作成用入力             |
-| input | CreateRoomInput       | ルーム作成用入力                 |
-| input | JoinRoomInput         | ルーム参加用入力                 |
-| input | InviteUserToRoomInput | ルーム招待用入力                 |
-| input | RoomFilterInput       | ルーム絞り込み条件入力           |
+| 種類  | 名称                  | 内容                                         |
+| ----- | --------------------- | -------------------------------------------- |
+| type  | User                  | ユーザー                                     |
+| type  | UserStatus            | ユーザーステータス                           |
+| type  | Profile               | ユーザープロフィール                         |
+| type  | Room                  | チャットルーム                               |
+| type  | RoomConnection        | チャットルームコネクション                   |
+| type  | RoomEdge              | チャットルームエッジ                         |
+| type  | RoomMemberConnection  | チャットルーム参加者コネクション             |
+| type  | RoomMemberEdge        | チャットルーム参加者エッジ                   |
+| type  | Message               | メッセージ                                   |
+| type  | MessageType           | メッセージタイプ                             |
+| type  | MessageConnection     | メッセージコネクション                       |
+| type  | MessageEdge           | メッセージエッジ                             |
+| type  | PageInfo              | ページ情報                                   |
+| input | CreateMessageInput    | メッセージ作成用入力                         |
+| input | CreateRoomInput       | ルーム作成用入力                             |
+| input | JoinRoomInput         | ルーム参加用入力                             |
+| input | InviteUserToRoomInput | ルーム招待用入力                             |
+| input | RoomFilterInput       | ルーム絞り込み条件入力                       |
+| type  | UserConnection        | ユーザーコネクション（ページネーション対応） |
+| type  | UserEdge              | ユーザーエッジ                               |
 
 ```graphql
 type User {
@@ -260,6 +270,21 @@ input RoomFilterInput {
 }
 ```
 
+```graphql
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+  totalCount: Int!
+}
+```
+
+```graphql
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+```
+
 ### 補足:Node Edge Connection など GraphQL に関連する用語の説明
 
 ```
@@ -268,8 +293,6 @@ Edge: Nodeと、そのNodeのリスト内での位置を示すカーソルを組
 Connection: Edgeのリストと、ページネーション情報 (PageInfo)、全体の件数 (totalCount) をまとめたもの。
 PageInfo: 次のページ有無やカーソル範囲など、ページ送りに関するメタ情報を提供する。
 ```
-
----
 
 ## 備考
 

--- a/frontend/src/app/(main)/chat/[roomId]/page.tsx
+++ b/frontend/src/app/(main)/chat/[roomId]/page.tsx
@@ -1,7 +1,7 @@
 import { isValidUUID } from "@/lib/validation";
-import { ChatInputArea } from "../components/chat-input-area";
 import { ChatMessageListContainer } from "../components/chat-message-list-container";
 import { ChatRoomHeaderContainer } from "../components/chat-room-header-container";
+import { ChatRoomInputOrJoinContainer } from "../components/chat-room-input-or-join-container";
 
 export default async function ChatRoomPage({
   params,
@@ -19,7 +19,7 @@ export default async function ChatRoomPage({
     <>
       <ChatRoomHeaderContainer roomId={roomId} />
       <ChatMessageListContainer roomId={roomId} />
-      <ChatInputArea roomId={roomId} />
+      <ChatRoomInputOrJoinContainer roomId={roomId} />
     </>
   );
 }

--- a/frontend/src/app/(main)/chat/actions/create-room-action.ts
+++ b/frontend/src/app/(main)/chat/actions/create-room-action.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { getGraphqlClient } from "@/lib/graphql-request/client";
+import { CreateRoomDocument } from "@/gql/graphql";
+import { getLoggedInUserId } from "../lib/get-logged-in-user-id";
+
+export async function createRoomAction(
+  name: string,
+  description?: string,
+): Promise<{ ok: boolean; roomId?: string; error?: string }> {
+  try {
+    const client = await getGraphqlClient();
+    const loggedInUserId = await getLoggedInUserId();
+
+    if (!loggedInUserId) {
+      return { ok: false, error: "ログインユーザーIDが取得できませんでした。" };
+    }
+
+    await client.request(CreateRoomDocument, {
+      input: {
+        name: name,
+        description: description,
+      },
+    });
+    return { ok: true, roomId: `作成に成功しました: ${name}` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "作成失敗" };
+  }
+}

--- a/frontend/src/app/(main)/chat/actions/invite-member-action.ts
+++ b/frontend/src/app/(main)/chat/actions/invite-member-action.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { getGraphqlClient } from "@/lib/graphql-request/client";
+import { getLoggedInUserId } from "../lib/get-logged-in-user-id";
+import { InviteUserToRoomDocument } from "@/gql/graphql";
+
+export async function InviteMemberAction(
+  roomId: string,
+  userId: string,
+): Promise<{ ok: boolean; roomId?: string; error?: string }> {
+  try {
+    const client = await getGraphqlClient();
+    const loggedInUserId = await getLoggedInUserId();
+
+    if (!loggedInUserId) {
+      return { ok: false, error: "ログインユーザーIDが取得できませんでした。" };
+    }
+
+    await client.request(InviteUserToRoomDocument, {
+      input: {
+        roomId: roomId,
+        userId: userId,
+      },
+    });
+    return { ok: true, roomId: `招待に成功しました: ${roomId}` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "招待失敗" };
+  }
+}

--- a/frontend/src/app/(main)/chat/actions/join-room-action.ts
+++ b/frontend/src/app/(main)/chat/actions/join-room-action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { getGraphqlClient } from "@/lib/graphql-request/client";
+import { JoinRoomDocument } from "@/gql/graphql";
+import { getLoggedInUserId } from "../lib/get-logged-in-user-id";
+
+export async function joinRoomAction(
+  roomId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const client = await getGraphqlClient();
+    const loggedInUserId = await getLoggedInUserId();
+
+    if (!loggedInUserId) {
+      return { ok: false, error: "ログインユーザーIDが取得できませんでした。" };
+    }
+
+    await client.request(JoinRoomDocument, {
+      input: {
+        roomId: roomId,
+      },
+    });
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "参加失敗" };
+  }
+}

--- a/frontend/src/app/(main)/chat/components/available-room-list.tsx
+++ b/frontend/src/app/(main)/chat/components/available-room-list.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { DialogTrigger } from "@radix-ui/react-dialog";
+import { useRouter } from "next/navigation";
 
 export type AvailableRoomListProps = {
   rooms: Array<{
@@ -10,6 +13,8 @@ export type AvailableRoomListProps = {
 };
 
 export function AvailableRoomList({ rooms }: AvailableRoomListProps) {
+  const router = useRouter();
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -32,6 +37,7 @@ export function AvailableRoomList({ rooms }: AvailableRoomListProps) {
                 <li
                   key={room.id}
                   className="p-2 rounded hover:bg-gray-100 cursor-pointer"
+                  onClick={() => router.push(`/chat/${room.id}`)}
                 >
                   # {room.name}
                 </li>

--- a/frontend/src/app/(main)/chat/components/chat-input-area.tsx
+++ b/frontend/src/app/(main)/chat/components/chat-input-area.tsx
@@ -19,14 +19,12 @@ export function ChatInputArea({ roomId }: { roomId: string }) {
 
   const handleSubmit = async () => {
     setIsLoading(true);
-
     const result = await sendMessageAction(value, roomId);
     if (result.ok) {
-      toast(result.message ?? "送信しました"); // TODO: toast周りの挙動は未調整
+      toast(result.message ?? "送信しました");
     } else {
       toast(`送信に失敗しました: ${result.error}`);
     }
-
     setValue("");
     setIsLoading(false);
   };

--- a/frontend/src/app/(main)/chat/components/chat-room-input-or-join-container.tsx
+++ b/frontend/src/app/(main)/chat/components/chat-room-input-or-join-container.tsx
@@ -1,0 +1,20 @@
+import { getGraphqlClient } from "@/lib/graphql-request/client";
+import { IsJoinedRoomDocument } from "@/gql/graphql";
+import { ChatInputArea } from "./chat-input-area";
+import { RoomJoinPromptContainer } from "./room-join-prompt-container";
+
+export async function ChatRoomInputOrJoinContainer({
+  roomId,
+}: {
+  roomId: string;
+}) {
+  const client = await getGraphqlClient();
+  const result = await client.request(IsJoinedRoomDocument, { roomId });
+  const isJoined = result?.isJoinedRoom;
+
+  if (isJoined) {
+    return <ChatInputArea roomId={roomId} />;
+  } else {
+    return <RoomJoinPromptContainer roomId={roomId} />;
+  }
+}

--- a/frontend/src/app/(main)/chat/components/create-room-dialog.tsx
+++ b/frontend/src/app/(main)/chat/components/create-room-dialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { DialogTrigger } from "@radix-ui/react-dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { useState, useTransition } from "react";
+import { createRoomAction } from "../actions/create-room-action";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+export function CreateRoomDialog() {
+  const [open, setOpen] = useState(false);
+  const [roomName, setRoomName] = useState("");
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <Plus size={16} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md w-full">
+        <DialogTitle className="text-2xl font-bold mb-6">
+          チャンネルを作成する
+        </DialogTitle>
+        <div className="mb-2 font-semibold">名前</div>
+        <Input
+          className="text-lg px-4 py-3 rounded-xl border-2 border-gray-200 mb-6"
+          placeholder="# 例: general"
+          value={roomName}
+          onChange={(e) => setRoomName(e.target.value)}
+        />
+        <div className="flex justify-end mt-4">
+          <Button
+            className="px-8 py-2 text-base font-semibold rounded-lg"
+            disabled={!roomName.trim() || pending}
+            onClick={() => {
+              startTransition(async () => {
+                const result = await createRoomAction(roomName);
+                if (result.ok) {
+                  toast("ルームを作成しました。", { description: roomName });
+                  setOpen(false);
+                  router.refresh();
+                } else {
+                  toast(`ルームの作成に失敗しました: ${result.error}`);
+                }
+              });
+            }}
+          >
+            {pending ? "作成中..." : "次へ"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(main)/chat/components/invite-member-dialog-container.tsx
+++ b/frontend/src/app/(main)/chat/components/invite-member-dialog-container.tsx
@@ -1,0 +1,39 @@
+import { getGraphqlClient } from "@/lib/graphql-request/client";
+import {
+  AvailableUsersForRoomDocument,
+  IsJoinedRoomDocument,
+} from "@/gql/graphql";
+import {
+  InviteMemberDialog,
+  InviteMemberDialogProps,
+} from "./invite-member-dialog";
+
+export async function InviteMemberDialogContainer({
+  roomId,
+}: {
+  roomId: string;
+}) {
+  const client = await getGraphqlClient();
+  const result = await client.request(IsJoinedRoomDocument, { roomId });
+  const isJoined = result?.isJoinedRoom;
+
+  if (!isJoined) {
+    return null;
+  }
+
+  const availableUsersForRoomDocument = await client.request(
+    AvailableUsersForRoomDocument,
+    { roomId },
+  );
+
+  const users: InviteMemberDialogProps["users"] =
+    availableUsersForRoomDocument.availableUsersForRoom.edges
+      .filter((edge) => edge.node.profile)
+      .map((edge) => ({
+        id: edge.node.id,
+        name: edge.node.profile!.name,
+        profileImageUrl: edge.node.profile!.profileImageUrl ?? "",
+      }));
+
+  return <InviteMemberDialog roomId={roomId} users={users} />;
+}

--- a/frontend/src/app/(main)/chat/components/invite-member-dialog.tsx
+++ b/frontend/src/app/(main)/chat/components/invite-member-dialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { DialogTrigger } from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui/button";
+import { UserPlus } from "lucide-react";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { InviteMemberAction } from "../actions/invite-member-action";
+import { toast } from "sonner";
+
+export type InviteMemberDialogProps = {
+  roomId: string;
+  users: Array<{
+    id: string;
+    name: string;
+    profileImageUrl: string;
+  }>;
+};
+
+export function InviteMemberDialog({ roomId, users }: InviteMemberDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <UserPlus size={18} />
+          招待
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md w-full">
+        <DialogTitle className="text-2xl font-bold">
+          メンバーを招待する
+        </DialogTitle>
+        <div>
+          {users.length === 0 ? (
+            <div className="text-gray-400">招待可能なユーザーはありません</div>
+          ) : (
+            <ul className="space-y-2">
+              {users.map((user) => (
+                <li
+                  key={user.id}
+                  className="p-2 rounded flex items-center gap-2 justify-between"
+                >
+                  <div className="flex items-center gap-2">
+                    <img
+                      src={user.profileImageUrl}
+                      alt={user.name + "のプロフィール画像"}
+                      className="w-8 h-8 rounded-full object-cover bg-gray-200"
+                    />
+                    {user.name}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => {
+                      startTransition(async () => {
+                        const result = await InviteMemberAction(
+                          roomId,
+                          user.id,
+                        );
+                        if (result.ok) {
+                          toast("ルームに招待しました。", {
+                            description: `ユーザー ${user.name} をルームに招待しました。`,
+                          });
+                          setOpen(false);
+                          router.refresh();
+                        } else {
+                          toast(
+                            `ルームへの招待に失敗しました: ${result.error}`,
+                          );
+                        }
+                      });
+                    }}
+                    disabled={pending}
+                  >
+                    招待する
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(main)/chat/components/joined-room-list.tsx
+++ b/frontend/src/app/(main)/chat/components/joined-room-list.tsx
@@ -1,3 +1,4 @@
+"use client";
 import {
   Collapsible,
   CollapsibleContent,
@@ -12,6 +13,8 @@ import {
   SidebarMenuButton,
 } from "@/components/ui/sidebar";
 import { ChevronRight } from "lucide-react";
+import { CreateRoomDialog } from "./create-room-dialog";
+import Link from "next/link";
 
 export type JoinedRoomListProps = {
   rooms: {
@@ -27,12 +30,15 @@ export function JoinedRoomList({ rooms }: JoinedRoomListProps) {
       <SidebarGroup>
         <SidebarGroupLabel
           asChild
-          className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
+          className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm flex items-center justify-between"
         >
-          <CollapsibleTrigger>
-            ルーム
-            <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
-          </CollapsibleTrigger>
+          <div className="flex items-center w-full">
+            <CollapsibleTrigger className="flex items-center flex-1">
+              ルーム
+              <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+            </CollapsibleTrigger>
+            <CreateRoomDialog />
+          </div>
         </SidebarGroupLabel>
         <CollapsibleContent>
           <SidebarGroupContent>
@@ -40,7 +46,7 @@ export function JoinedRoomList({ rooms }: JoinedRoomListProps) {
               {rooms.map((room) => (
                 <SidebarMenuItem key={room.id}>
                   <SidebarMenuButton asChild isActive={room.isActive}>
-                    <a href={`/chat/${room.id}`}># {room.name}</a>
+                    <Link href={`/chat/${room.id}`}># {room.name}</Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}

--- a/frontend/src/app/(main)/chat/components/room-join-prompt-container.tsx
+++ b/frontend/src/app/(main)/chat/components/room-join-prompt-container.tsx
@@ -1,9 +1,8 @@
-import { AppHeader } from "@/components/layout/app-header";
 import { RoomDocument } from "@/gql/graphql";
 import { getGraphqlClient } from "@/lib/graphql-request/client";
-import { InviteMemberDialogContainer } from "./invite-member-dialog-container";
+import { RoomJoinPrompt } from "./room-join-prompt";
 
-export async function ChatRoomHeaderContainer({ roomId }: { roomId: string }) {
+export async function RoomJoinPromptContainer({ roomId }: { roomId: string }) {
   const client = await getGraphqlClient();
   const roomDocument = await client.request(RoomDocument, {
     roomId,
@@ -15,10 +14,5 @@ export async function ChatRoomHeaderContainer({ roomId }: { roomId: string }) {
   }
 
   const title = roomDocument?.room?.name ?? "不明なルーム";
-  return (
-    <AppHeader
-      pageTitle={title}
-      actions={<InviteMemberDialogContainer roomId={roomId} />}
-    />
-  );
+  return <RoomJoinPrompt roomName={title} roomId={roomId} />;
 }

--- a/frontend/src/app/(main)/chat/components/room-join-prompt.tsx
+++ b/frontend/src/app/(main)/chat/components/room-join-prompt.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { joinRoomAction } from "../actions/join-room-action";
+import { useRouter } from "next/navigation";
+
+export type RoomJoinPromptProps = {
+  roomId: string;
+  roomName: string;
+};
+
+export function RoomJoinPrompt({ roomId, roomName }: RoomJoinPromptProps) {
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  return (
+    <div id="chat-input-area" className="flex justify-center items-center py-8">
+      <Card className="w-full max-w-3xl mx-auto flex flex-col items-center bg-gray-50 p-8">
+        <div className="text-2xl font-bold mb-6"># {roomName}</div>
+        <Button
+          className="text-lg font-bold px-8 py-4"
+          onClick={() => {
+            startTransition(async () => {
+              const result = await joinRoomAction(roomId);
+              if (result.ok) {
+                toast("チャンネルに参加しました");
+                router.refresh();
+              } else {
+                toast(`参加に失敗しました: ${result.error}`);
+              }
+            });
+          }}
+          disabled={pending}
+        >
+          {pending ? "参加中..." : "チャンネルに参加する"}
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/chat/graphql/available-users-for-room.graphql
+++ b/frontend/src/app/(main)/chat/graphql/available-users-for-room.graphql
@@ -1,0 +1,17 @@
+query AvailableUsersForRoom($roomId: ID!, $first: Int, $after: String) {
+  availableUsersForRoom(roomId: $roomId, first: $first, after: $after) {
+    edges {
+      cursor
+      node {
+        ...UserProfileFragment
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
+  }
+}

--- a/frontend/src/app/(main)/chat/graphql/create-room.graphql
+++ b/frontend/src/app/(main)/chat/graphql/create-room.graphql
@@ -1,0 +1,11 @@
+mutation CreateRoom($input: CreateRoomInput!) {
+  createRoom(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    createUserId
+    updateUserId
+  }
+}

--- a/frontend/src/app/(main)/chat/graphql/invite-user-to-room.graphql
+++ b/frontend/src/app/(main)/chat/graphql/invite-user-to-room.graphql
@@ -1,0 +1,9 @@
+mutation InviteUserToRoom($input: InviteUserToRoomInput!) {
+  inviteUserToRoom(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+  }
+}

--- a/frontend/src/app/(main)/chat/graphql/is-joined-room.graphql
+++ b/frontend/src/app/(main)/chat/graphql/is-joined-room.graphql
@@ -1,0 +1,3 @@
+query IsJoinedRoom($roomId: ID!) {
+  isJoinedRoom(roomId: $roomId)
+}

--- a/frontend/src/app/(main)/chat/graphql/join-room.graphql
+++ b/frontend/src/app/(main)/chat/graphql/join-room.graphql
@@ -1,0 +1,6 @@
+mutation JoinRoom($input: JoinRoomInput!) {
+  joinRoom(input: $input) {
+    id
+    name
+  }
+}

--- a/frontend/src/app/(main)/chat/graphql/user-profile-fragment.graphql
+++ b/frontend/src/app/(main)/chat/graphql/user-profile-fragment.graphql
@@ -1,0 +1,7 @@
+fragment UserProfileFragment on User {
+  id
+  profile {
+    name
+    profileImageUrl
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { UrqlClientProvider } from "@/components/provider/urql-client-provider";
 import { SessionProvider } from "next-auth/react";
 import { auth } from "@/auth";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -34,6 +35,7 @@ export default async function RootLayout({
         <SessionProvider session={session}>
           <UrqlClientProvider>{children}</UrqlClientProvider>
         </SessionProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -3,9 +3,10 @@ import { Separator } from "@radix-ui/react-separator";
 
 type HeaderProps = {
   pageTitle: string;
+  actions?: React.ReactNode;
 };
 
-export function AppHeader({ pageTitle }: HeaderProps) {
+export function AppHeader({ pageTitle, actions }: HeaderProps) {
   return (
     <header className="bg-background sticky top-0 z-50 flex h-16 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
@@ -13,6 +14,7 @@ export function AppHeader({ pageTitle }: HeaderProps) {
       <h2 className="scroll-m-20 text-xl font-semibold tracking-tight">
         # {pageTitle}
       </h2>
+      <div className="ml-auto">{actions}</div>
     </header>
   );
 }

--- a/frontend/src/gql/gql.ts
+++ b/frontend/src/gql/gql.ts
@@ -14,20 +14,32 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 type Documents = {
+    "query AvailableUsersForRoom($roomId: ID!, $first: Int, $after: String) {\n  availableUsersForRoom(roomId: $roomId, first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        ...UserProfileFragment\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    totalCount\n  }\n}": typeof types.AvailableUsersForRoomDocument,
     "mutation CreateMessage($input: CreateMessageInput!) {\n  createMessage(input: $input) {\n    id\n    sender {\n      profile {\n        name\n      }\n    }\n    contents\n    createdAt\n    updatedAt\n  }\n}": typeof types.CreateMessageDocument,
+    "mutation CreateRoom($input: CreateRoomInput!) {\n  createRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n    createUserId\n    updateUserId\n  }\n}": typeof types.CreateRoomDocument,
+    "mutation InviteUserToRoom($input: InviteUserToRoomInput!) {\n  inviteUserToRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n  }\n}": typeof types.InviteUserToRoomDocument,
+    "query IsJoinedRoom($roomId: ID!) {\n  isJoinedRoom(roomId: $roomId)\n}": typeof types.IsJoinedRoomDocument,
+    "mutation JoinRoom($input: JoinRoomInput!) {\n  joinRoom(input: $input) {\n    id\n    name\n  }\n}": typeof types.JoinRoomDocument,
     "subscription MessageAdded {\n  messageAdded {\n    ...MessageItemFragment\n  }\n}": typeof types.MessageAddedDocument,
     "fragment MessageItemFragment on Message {\n  id\n  contents\n  sender {\n    id\n    profile {\n      name\n      profileImageUrl\n    }\n  }\n}": typeof types.MessageItemFragmentFragmentDoc,
     "query MessagesByRoom($roomId: ID!, $first: Int, $last: Int, $after: String, $before: String) {\n  messagesConnectionByRoom(\n    roomId: $roomId\n    first: $first\n    last: $last\n    after: $after\n    before: $before\n  ) {\n    totalCount\n    edges {\n      cursor\n      node {\n        ...MessageItemFragment\n        createdAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}": typeof types.MessagesByRoomDocument,
     "query Room($roomId: ID!) {\n  room(id: $roomId) {\n    name\n  }\n}": typeof types.RoomDocument,
     "query RoomsConnection($first: Int, $after: String, $filter: RoomFilterInput) {\n  roomsConnection(first: $first, after: $after, filter: $filter) {\n    edges {\n      cursor\n      node {\n        id\n        name\n        description\n        createdAt\n        updatedAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}": typeof types.RoomsConnectionDocument,
+    "fragment UserProfileFragment on User {\n  id\n  profile {\n    name\n    profileImageUrl\n  }\n}": typeof types.UserProfileFragmentFragmentDoc,
 };
 const documents: Documents = {
+    "query AvailableUsersForRoom($roomId: ID!, $first: Int, $after: String) {\n  availableUsersForRoom(roomId: $roomId, first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        ...UserProfileFragment\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    totalCount\n  }\n}": types.AvailableUsersForRoomDocument,
     "mutation CreateMessage($input: CreateMessageInput!) {\n  createMessage(input: $input) {\n    id\n    sender {\n      profile {\n        name\n      }\n    }\n    contents\n    createdAt\n    updatedAt\n  }\n}": types.CreateMessageDocument,
+    "mutation CreateRoom($input: CreateRoomInput!) {\n  createRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n    createUserId\n    updateUserId\n  }\n}": types.CreateRoomDocument,
+    "mutation InviteUserToRoom($input: InviteUserToRoomInput!) {\n  inviteUserToRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n  }\n}": types.InviteUserToRoomDocument,
+    "query IsJoinedRoom($roomId: ID!) {\n  isJoinedRoom(roomId: $roomId)\n}": types.IsJoinedRoomDocument,
+    "mutation JoinRoom($input: JoinRoomInput!) {\n  joinRoom(input: $input) {\n    id\n    name\n  }\n}": types.JoinRoomDocument,
     "subscription MessageAdded {\n  messageAdded {\n    ...MessageItemFragment\n  }\n}": types.MessageAddedDocument,
     "fragment MessageItemFragment on Message {\n  id\n  contents\n  sender {\n    id\n    profile {\n      name\n      profileImageUrl\n    }\n  }\n}": types.MessageItemFragmentFragmentDoc,
     "query MessagesByRoom($roomId: ID!, $first: Int, $last: Int, $after: String, $before: String) {\n  messagesConnectionByRoom(\n    roomId: $roomId\n    first: $first\n    last: $last\n    after: $after\n    before: $before\n  ) {\n    totalCount\n    edges {\n      cursor\n      node {\n        ...MessageItemFragment\n        createdAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}": types.MessagesByRoomDocument,
     "query Room($roomId: ID!) {\n  room(id: $roomId) {\n    name\n  }\n}": types.RoomDocument,
     "query RoomsConnection($first: Int, $after: String, $filter: RoomFilterInput) {\n  roomsConnection(first: $first, after: $after, filter: $filter) {\n    edges {\n      cursor\n      node {\n        id\n        name\n        description\n        createdAt\n        updatedAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}": types.RoomsConnectionDocument,
+    "fragment UserProfileFragment on User {\n  id\n  profile {\n    name\n    profileImageUrl\n  }\n}": types.UserProfileFragmentFragmentDoc,
 };
 
 /**
@@ -47,7 +59,27 @@ export function graphql(source: string): unknown;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
+export function graphql(source: "query AvailableUsersForRoom($roomId: ID!, $first: Int, $after: String) {\n  availableUsersForRoom(roomId: $roomId, first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        ...UserProfileFragment\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    totalCount\n  }\n}"): (typeof documents)["query AvailableUsersForRoom($roomId: ID!, $first: Int, $after: String) {\n  availableUsersForRoom(roomId: $roomId, first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        ...UserProfileFragment\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    totalCount\n  }\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(source: "mutation CreateMessage($input: CreateMessageInput!) {\n  createMessage(input: $input) {\n    id\n    sender {\n      profile {\n        name\n      }\n    }\n    contents\n    createdAt\n    updatedAt\n  }\n}"): (typeof documents)["mutation CreateMessage($input: CreateMessageInput!) {\n  createMessage(input: $input) {\n    id\n    sender {\n      profile {\n        name\n      }\n    }\n    contents\n    createdAt\n    updatedAt\n  }\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "mutation CreateRoom($input: CreateRoomInput!) {\n  createRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n    createUserId\n    updateUserId\n  }\n}"): (typeof documents)["mutation CreateRoom($input: CreateRoomInput!) {\n  createRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n    createUserId\n    updateUserId\n  }\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "mutation InviteUserToRoom($input: InviteUserToRoomInput!) {\n  inviteUserToRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n  }\n}"): (typeof documents)["mutation InviteUserToRoom($input: InviteUserToRoomInput!) {\n  inviteUserToRoom(input: $input) {\n    id\n    name\n    description\n    createdAt\n    updatedAt\n  }\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "query IsJoinedRoom($roomId: ID!) {\n  isJoinedRoom(roomId: $roomId)\n}"): (typeof documents)["query IsJoinedRoom($roomId: ID!) {\n  isJoinedRoom(roomId: $roomId)\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "mutation JoinRoom($input: JoinRoomInput!) {\n  joinRoom(input: $input) {\n    id\n    name\n  }\n}"): (typeof documents)["mutation JoinRoom($input: JoinRoomInput!) {\n  joinRoom(input: $input) {\n    id\n    name\n  }\n}"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -68,6 +100,10 @@ export function graphql(source: "query Room($roomId: ID!) {\n  room(id: $roomId)
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "query RoomsConnection($first: Int, $after: String, $filter: RoomFilterInput) {\n  roomsConnection(first: $first, after: $after, filter: $filter) {\n    edges {\n      cursor\n      node {\n        id\n        name\n        description\n        createdAt\n        updatedAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}"): (typeof documents)["query RoomsConnection($first: Int, $after: String, $filter: RoomFilterInput) {\n  roomsConnection(first: $first, after: $after, filter: $filter) {\n    edges {\n      cursor\n      node {\n        id\n        name\n        description\n        createdAt\n        updatedAt\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "fragment UserProfileFragment on User {\n  id\n  profile {\n    name\n    profileImageUrl\n  }\n}"): (typeof documents)["fragment UserProfileFragment on User {\n  id\n  profile {\n    name\n    profileImageUrl\n  }\n}"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -156,10 +156,26 @@ export type Profile = {
 
 export type Query = {
   __typename?: 'Query';
+  availableUsersForRoom: UserConnection;
+  isJoinedRoom: Scalars['Boolean']['output'];
   membersConnectionByRoom: RoomMemberConnection;
   messagesConnectionByRoom: MessageConnection;
   room?: Maybe<Room>;
   roomsConnection: RoomConnection;
+};
+
+
+export type QueryAvailableUsersForRoomArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  roomId: Scalars['ID']['input'];
+};
+
+
+export type QueryIsJoinedRoomArgs = {
+  roomId: Scalars['ID']['input'];
 };
 
 
@@ -282,6 +298,19 @@ export type User = {
   userStatus: UserStatus;
 };
 
+export type UserConnection = {
+  __typename?: 'UserConnection';
+  edges: Array<UserEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type UserEdge = {
+  __typename?: 'UserEdge';
+  cursor: Scalars['String']['output'];
+  node: User;
+};
+
 export type UserStatus = {
   __typename?: 'UserStatus';
   /** 作成日時 */
@@ -296,12 +325,49 @@ export type UserStatus = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
+export type AvailableUsersForRoomQueryVariables = Exact<{
+  roomId: Scalars['ID']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AvailableUsersForRoomQuery = { __typename?: 'Query', availableUsersForRoom: { __typename?: 'UserConnection', totalCount: number, edges: Array<{ __typename?: 'UserEdge', cursor: string, node: { __typename?: 'User', id: string, profile?: { __typename?: 'Profile', name: string, profileImageUrl?: string | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+
 export type CreateMessageMutationVariables = Exact<{
   input: CreateMessageInput;
 }>;
 
 
 export type CreateMessageMutation = { __typename?: 'Mutation', createMessage: { __typename?: 'Message', id: string, contents: string, createdAt: any, updatedAt: any, sender: { __typename?: 'User', profile?: { __typename?: 'Profile', name: string } | null } } };
+
+export type CreateRoomMutationVariables = Exact<{
+  input: CreateRoomInput;
+}>;
+
+
+export type CreateRoomMutation = { __typename?: 'Mutation', createRoom: { __typename?: 'Room', id: string, name: string, description?: string | null, createdAt: any, updatedAt: any, createUserId: string, updateUserId: string } };
+
+export type InviteUserToRoomMutationVariables = Exact<{
+  input: InviteUserToRoomInput;
+}>;
+
+
+export type InviteUserToRoomMutation = { __typename?: 'Mutation', inviteUserToRoom: { __typename?: 'Room', id: string, name: string, description?: string | null, createdAt: any, updatedAt: any } };
+
+export type IsJoinedRoomQueryVariables = Exact<{
+  roomId: Scalars['ID']['input'];
+}>;
+
+
+export type IsJoinedRoomQuery = { __typename?: 'Query', isJoinedRoom: boolean };
+
+export type JoinRoomMutationVariables = Exact<{
+  input: JoinRoomInput;
+}>;
+
+
+export type JoinRoomMutation = { __typename?: 'Mutation', joinRoom: { __typename?: 'Room', id: string, name: string } };
 
 export type MessageAddedSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
@@ -337,8 +403,16 @@ export type RoomsConnectionQueryVariables = Exact<{
 
 export type RoomsConnectionQuery = { __typename?: 'Query', roomsConnection: { __typename?: 'RoomConnection', edges: Array<{ __typename?: 'RoomEdge', cursor: string, node: { __typename?: 'Room', id: string, name: string, description?: string | null, createdAt: any, updatedAt: any } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
+export type UserProfileFragmentFragment = { __typename?: 'User', id: string, profile?: { __typename?: 'Profile', name: string, profileImageUrl?: string | null } | null };
+
 export const MessageItemFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MessageItemFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Message"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"contents"}},{"kind":"Field","name":{"kind":"Name","value":"sender"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]}}]} as unknown as DocumentNode<MessageItemFragmentFragment, unknown>;
+export const UserProfileFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserProfileFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"User"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]} as unknown as DocumentNode<UserProfileFragmentFragment, unknown>;
+export const AvailableUsersForRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AvailableUsersForRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"first"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"after"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"availableUsersForRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"roomId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}}},{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"first"}}},{"kind":"Argument","name":{"kind":"Name","value":"after"},"value":{"kind":"Variable","name":{"kind":"Name","value":"after"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UserProfileFragment"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"pageInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"hasPreviousPage"}},{"kind":"Field","name":{"kind":"Name","value":"startCursor"}},{"kind":"Field","name":{"kind":"Name","value":"endCursor"}}]}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserProfileFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"User"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]} as unknown as DocumentNode<AvailableUsersForRoomQuery, AvailableUsersForRoomQueryVariables>;
 export const CreateMessageDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateMessage"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateMessageInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createMessage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"sender"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"contents"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<CreateMessageMutation, CreateMessageMutationVariables>;
+export const CreateRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateRoomInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"createUserId"}},{"kind":"Field","name":{"kind":"Name","value":"updateUserId"}}]}}]}}]} as unknown as DocumentNode<CreateRoomMutation, CreateRoomMutationVariables>;
+export const InviteUserToRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"InviteUserToRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"InviteUserToRoomInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"inviteUserToRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<InviteUserToRoomMutation, InviteUserToRoomMutationVariables>;
+export const IsJoinedRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"IsJoinedRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"isJoinedRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"roomId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}}}]}]}}]} as unknown as DocumentNode<IsJoinedRoomQuery, IsJoinedRoomQueryVariables>;
+export const JoinRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"JoinRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JoinRoomInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"joinRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<JoinRoomMutation, JoinRoomMutationVariables>;
 export const MessageAddedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"MessageAdded"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"messageAdded"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MessageItemFragment"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MessageItemFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Message"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"contents"}},{"kind":"Field","name":{"kind":"Name","value":"sender"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]}}]} as unknown as DocumentNode<MessageAddedSubscription, MessageAddedSubscriptionVariables>;
 export const MessagesByRoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MessagesByRoom"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"first"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"last"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"after"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"before"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"messagesConnectionByRoom"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"roomId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}}},{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"first"}}},{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"Variable","name":{"kind":"Name","value":"last"}}},{"kind":"Argument","name":{"kind":"Name","value":"after"},"value":{"kind":"Variable","name":{"kind":"Name","value":"after"}}},{"kind":"Argument","name":{"kind":"Name","value":"before"},"value":{"kind":"Variable","name":{"kind":"Name","value":"before"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MessageItemFragment"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"pageInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"hasPreviousPage"}},{"kind":"Field","name":{"kind":"Name","value":"startCursor"}},{"kind":"Field","name":{"kind":"Name","value":"endCursor"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MessageItemFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Message"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"contents"}},{"kind":"Field","name":{"kind":"Name","value":"sender"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"profile"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]}}]} as unknown as DocumentNode<MessagesByRoomQuery, MessagesByRoomQueryVariables>;
 export const RoomDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Room"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"room"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"roomId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<RoomQuery, RoomQueryVariables>;


### PR DESCRIPTION
## 概要
- チャットルームの作成・参加・招待に対応したフロントエンド機能を実装しました。

## 主な内容
- チャットルームの新規作成・参加・ユーザー招待のUI実装
- GraphQL APIを利用したチャットルーム操作の実装
- 未参加ユーザーの取得・表示機能の追加